### PR TITLE
refactor `write_meta_error` function and add `write_meta_error_string…

### DIFF
--- a/netpalm/backend/core/models/task.py
+++ b/netpalm/backend/core/models/task.py
@@ -29,7 +29,7 @@ class TaskMetaData(BaseModel):
 
 class TaskError(BaseModel):
     exception_class: str
-    exception_args: [List[str]]
+    exception_args: List[str]
 
 
 class TaskResponse(BaseModel):


### PR DESCRIPTION
…` function

`write_meta_error_string` has exactly same behavior as `write_meta_error` used to.

`write_meta_error`:
  * Acts on Exception objects
  * walks the entire stack trace to discover ancestor exceptions (i.e. if a socket error cause a paramiko error caused a netmiko error caused a napalm error)
  * adds object with "exception_class" and "exception_args" for each error to error list (ensuring "root cause" error is at top of list)
    * `RuntimeError("foo") becomes {"exception_class": "RuntimeError", "exception_args": ["foo"]}`