### PR TITLE
use exception __context__ instead of __cause__ to walk back errors.

### DIFF
--- a/netpalm/backend/core/utilities/rediz_meta.py
+++ b/netpalm/backend/core/utilities/rediz_meta.py
@@ -21,15 +21,16 @@ def exception_full_name(exception: BaseException):
 
 def yield_exception_chain(exc: BaseException):
     yield exc
-    if exc.__cause__ is None:
+    if exc.__context__ is None:
         return
-    yield from yield_exception_chain(exc.__cause__)
+    yield from yield_exception_chain(exc.__context__)
 
 
 def write_meta_error(exception: Exception):
     """custom exception handler for within an rpc job"""
     if isinstance(exception, NetpalmMetaProcessedException):
-        return  # Don't process the same exception twice
+        raise exception from None  # Don't process the same exception twice
+
     job = get_current_job()
     job.meta["result"] = "failed"
 


### PR DESCRIPTION
Also re-raise exceptions always just to ensure they get logged to console and handled by stuff like sentry